### PR TITLE
Support partition for KurrentDBClient.get_projection_state()

### DIFF
--- a/README.md
+++ b/README.md
@@ -2978,7 +2978,11 @@ The `get_projection_state()` method can be used to get a projection's "state".
 This method has a required `name` argument, which is a Python `str` that
 specifies the name of a projection.
 
-This method also has two optional arguments, `timeout` and `credentials`.
+This method also has three optional arguments, `partition`, `timeout` and
+`credentials`.
+
+The optional `partition` argument is a Python `str` which can be used to read
+the state of a particular partition.
 
 The optional `timeout` argument is a Python `float` which sets a
 maximum duration, in seconds, for the completion of the gRPC operation.

--- a/kurrentdbclient/client.py
+++ b/kurrentdbclient/client.py
@@ -1890,6 +1890,7 @@ class KurrentDBClient(BaseKurrentDBClient):
     def get_projection_state(
         self,
         name: str,
+        partition: str | None = None,
         *,
         timeout: float | None = None,
         credentials: grpc.CallCredentials | None = None,
@@ -1898,10 +1899,11 @@ class KurrentDBClient(BaseKurrentDBClient):
         Gets projection state.
         """
         timeout = timeout if timeout is not None else self._default_deadline
+        partition = partition if partition is not None else ""
 
         return self.projections.get_state(
             name=name,
-            partition="",
+            partition=partition,
             timeout=timeout,
             metadata=self._call_metadata,
             credentials=credentials or self._call_credentials,


### PR DESCRIPTION
What has changed:
- Exposed the partition attribute of the gRPC call to get_projection_state()
- Added the optional parameter to README.md
- Added a test case

@johnbywater Please let me know if there are any changes you would recommend.